### PR TITLE
ci: Update workflow to version v0.26.0

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -12,11 +12,11 @@ concurrency:
 jobs:
   version:
     name: Version
-    uses: cupel-co/workflows/.github/workflows/version.generate.yml@v0.24.0
+    uses: cupel-co/workflows/.github/workflows/version.generate.yml@v0.26.0
 
   release:
     name: Release
-    uses: cupel-co/workflows/.github/workflows/release.github.yml@v0.24.0
+    uses: cupel-co/workflows/.github/workflows/release.github.yml@v0.26.0
     needs:
       - version
     permissions:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -14,4 +14,4 @@ concurrency:
 jobs:
   version:
     name: Version
-    uses: cupel-co/workflows/.github/workflows/version.generate.yml@v0.24.0
+    uses: cupel-co/workflows/.github/workflows/version.generate.yml@v0.26.0

--- a/.github/workflows/pull-request-notify.yml
+++ b/.github/workflows/pull-request-notify.yml
@@ -13,6 +13,6 @@ concurrency:
 jobs:
   pull-request:
     name: Pull Request
-    uses: cupel-co/workflows/.github/workflows/pull-request.notify.yml@v0.24.0
+    uses: cupel-co/workflows/.github/workflows/pull-request.notify.yml@v0.26.0
     secrets:
       google-chat-webhook-url: '${{ secrets.GOOGLE_CHAT_WEBHOOK_URL }}'

--- a/.github/workflows/pull-request-update.yml
+++ b/.github/workflows/pull-request-update.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   pull-request:
     name: Pull Request
-    uses: cupel-co/workflows/.github/workflows/pull-request.update.yml@v0.24.0
+    uses: cupel-co/workflows/.github/workflows/pull-request.update.yml@v0.26.0
     permissions:
       issues: read
       pull-requests: write


### PR DESCRIPTION
# #6 - ci: Update workflow to version v0.26.0

[![Preview](https://github.com/cupel-co/cupel-co/actions/workflows/preview.yml/badge.svg?branch=ci/GH-6-update-workflows&event=pull_request)](https://github.com/cupel-co/cupel-co/actions/workflows/preview.yml?query=branch%3Aci/GH-6-update-workflows)

## Description
* closes #6
*
* 
