### PR TITLE
fix: update name of release workflow

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -16,7 +16,7 @@ jobs:
 
   release:
     name: Release
-    uses: cupel-co/workflows/.github/workflows/release.github.yml@v0.26.0
+    uses: cupel-co/workflows/.github/workflows/release.create.yml@v0.26.0
     needs:
       - version
     permissions:


### PR DESCRIPTION
# #6 - fix: update name of release workflow

[![Preview](https://github.com/cupel-co/cupel-co/actions/workflows/preview.yml/badge.svg?branch=fix/GH-6-update-workflow&event=pull_request)](https://github.com/cupel-co/cupel-co/actions/workflows/preview.yml?query=branch%3Afix/GH-6-update-workflow)

## Description
* closes #6
*
* 
